### PR TITLE
Minor bug fixes from IOI 2019

### DIFF
--- a/cms/grading/scoretypes/abc.py
+++ b/cms/grading/scoretypes/abc.py
@@ -218,7 +218,7 @@ class ScoreTypeGroup(ScoreTypeAlone):
     {% endif %}
     <div class="subtask-head">
         <span class="title">
-            {% trans index=st["idx"] %}Subtask {{ index }}{% endtrans %}
+            {% trans index=st["idx"]-1 %}Subtask {{ index }}{% endtrans %}
         </span>
     {% if "score_fraction" in st and "max_score" in st %}
         {% set score = st["score_fraction"] * st["max_score"] %}

--- a/cms/grading/tasktypes/OutputOnly.py
+++ b/cms/grading/tasktypes/OutputOnly.py
@@ -51,7 +51,7 @@ class OutputOnly(TaskType):
     CHECKER_CODENAME = "checker"
     # Template for the filename of the output files provided by the user; %s
     # represent the testcase codename.
-    USER_OUTPUT_FILENAME_TEMPLATE = "output_%s.txt"
+    USER_OUTPUT_FILENAME_TEMPLATE = "%s.out"
 
     # Constants used in the parameter definition.
     OUTPUT_EVAL_DIFF = "diff"

--- a/cms/service/ProxyService.py
+++ b/cms/service/ProxyService.py
@@ -336,7 +336,7 @@ class ProxyService(TriggeredService):
                     users[encode_id(user.username)] = {
                         "f_name": user.first_name,
                         "l_name": user.last_name,
-                        "team": team.code if team is not None else None,
+                        "team": encode_id(team.code) if team is not None else None,
                     }
                     if team is not None:
                         teams[encode_id(team.code)] = {

--- a/cmscommon/mimetypes.py
+++ b/cmscommon/mimetypes.py
@@ -85,7 +85,7 @@ def get_type_for_file_name(filename):
     """
 
     # Temporary fix from IOI 2019, not sure if needed anymore
-    if filename.endswith(".out"):
+    if filename.endswith(".out") or filename.endswith(".in"):
         filename = "hack.txt"
 
     mimetype = xdg.Mime.get_type_by_name(filename)

--- a/cmscommon/mimetypes.py
+++ b/cmscommon/mimetypes.py
@@ -83,6 +83,11 @@ def get_type_for_file_name(filename):
         e.g., "application/pdf".
 
     """
+
+    # Temporary fix from IOI 2019, not sure if needed anymore
+    if filename.endswith(".out"):
+        filename = "hack.txt"
+
     mimetype = xdg.Mime.get_type_by_name(filename)
     if mimetype is None:
         return None


### PR DESCRIPTION

4 | Minor bug fixes from IOI 2019 CMS |   |  
-- | -- | -- | --
4.1 | Subtask numbering starts from 0, Output only filename format changed | cherry-pick | https://github.com/ioi-2019/cms-ioi2019/commit/a5d5e0f34e75f99a0ff9dc43e43bc5d7e02e414b
4.2 | bugfix: '-' character in contestant username | cherry-pick | https://github.com/ioi-2019/cms-ioi2019/commit/13f86cfd5ad6833925162ac0665177dc9ba73dd0
4.3 | fix error on download of .out files | cherry-pick | https://github.com/ioi-2019/cms-ioi2019/commit/f747b5b2b33cf15a19946325cc98d202d09151d5
4.4 | same with .in just to be safe | cherry-pick | https://github.com/ioi-2019/cms-ioi2019/commit/ba01ac44ca42066bbeed62497de28eef4441c08d

