### PR TITLE
Update JVM Configurations from IOI 2019

### DIFF
--- a/cms/grading/languages/java_jdk.py
+++ b/cms/grading/languages/java_jdk.py
@@ -79,9 +79,11 @@ class JavaJDK(Language):
             # executable_filename is a jar file, main is the name of
             # the main java class
             return [["/usr/bin/java", "-Deval=true", "-Xmx1024M", "-Xss1024M",
-                     "-cp", executable_filename, main] + args]
+                     "-Xbatch", "-XX:+UseSerialGC", "-XX:-TieredCompilation",
+	                     "-XX:CICompilerCount=1", "-cp", executable_filename, main] + args]
         else:
             unzip_command = ["/usr/bin/unzip", executable_filename]
             command = ["/usr/bin/java", "-Deval=true", "-Xmx1024M", "-Xss1024M",
-                       main] + args
+                       "-Xbatch", "-XX:+UseSerialGC", "-XX:-TieredCompilation",
+	                       "-XX:CICompilerCount=1", main] + args
             return [unzip_command, command]

--- a/cms/grading/languages/java_jdk.py
+++ b/cms/grading/languages/java_jdk.py
@@ -78,10 +78,10 @@ class JavaJDK(Language):
         if JavaJDK.USE_JAR:
             # executable_filename is a jar file, main is the name of
             # the main java class
-            return [["/usr/bin/java", "-Deval=true", "-Xmx512M", "-Xss64M",
+            return [["/usr/bin/java", "-Deval=true", "-Xmx1024M", "-Xss1024M",
                      "-cp", executable_filename, main] + args]
         else:
             unzip_command = ["/usr/bin/unzip", executable_filename]
-            command = ["/usr/bin/java", "-Deval=true", "-Xmx512M", "-Xss64M",
+            command = ["/usr/bin/java", "-Deval=true", "-Xmx1024M", "-Xss1024M",
                        main] + args
             return [unzip_command, command]

--- a/cms/grading/languages/java_jdk.py
+++ b/cms/grading/languages/java_jdk.py
@@ -78,12 +78,13 @@ class JavaJDK(Language):
         if JavaJDK.USE_JAR:
             # executable_filename is a jar file, main is the name of
             # the main java class
-            return [["/usr/bin/java", "-Deval=true", "-Xmx1024M", "-Xss1024M",
+	    # Suggested by Martin to be lowered by 24MB given problem limit of 1024MB
+            return [["/usr/bin/java", "-Deval=true", "-Xmx1000M", "-Xss1000M",
                      "-Xbatch", "-XX:+UseSerialGC", "-XX:-TieredCompilation",
 	                     "-XX:CICompilerCount=1", "-cp", executable_filename, main] + args]
         else:
             unzip_command = ["/usr/bin/unzip", executable_filename]
-            command = ["/usr/bin/java", "-Deval=true", "-Xmx1024M", "-Xss1024M",
+            command = ["/usr/bin/java", "-Deval=true", "-Xmx1000M", "-Xss1000M",
                        "-Xbatch", "-XX:+UseSerialGC", "-XX:-TieredCompilation",
 	                       "-XX:CICompilerCount=1", main] + args
             return [unzip_command, command]


### PR DESCRIPTION

5 | Update JVM configurations |   |  
-- | -- | -- | --
5.1 | fix: increase JVM heap and stack size (ioi 2019) | cherry-pick | https://github.com/ioi-2019/cms-ioi2019/commit/50d7b6fd3582884e0634582933cebd518aa4900e
5.2 | feat: made JVM more deterministic acording to the checklist (ioi 2019) | cherry-pick | https://github.com/ioi-2019/cms-ioi2019/commit/951c1c14ad7128b0d3abdf1b47d50a581c828d85
5.3 | fix: java memory size lowered by 24MB | cherry-pick | https://github.com/ioi-2019/cms-ioi2019/commit/45d7d9477089f67b65d06a4ac2bfdc0e47eb565d

